### PR TITLE
Add GPT-OSS-20B Tutorial and README Update for CUREBench Participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple inference framework for the CURE-Bench bio-medical AI competition. This
 
 ## Updates
  2025.08.08: **[Question&Answer page](QA.md)**: We have created a Q&A page to share all our responses to questions from participants, ensuring fair competition.
+ 2025.09.10: Added instructions for running **GPT-OSS-20B**, OpenAI’s 20B open-weight reasoning model.
 
 ## Quick Start
 
@@ -24,13 +25,23 @@ export AZURE_OPENAI_API_KEY_O1="your-api-key"
 export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
 ```
 
-If you want to use the open-ended models, such as Qwen:
+If you want to use the open-ended models, (e.g., Qwen, GPT-OSS-20B):
 For local models, ensure you have sufficient GPU memory:
 ```bash
 # Install CUDA-compatible PyTorch if needed
 # pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 pip install transfomers
 ```
+**Using GPT-OSS-20B:**
+
+[GPT-OSS-20B](https://huggingface.co/openai/gpt-oss-20b) is an open-weight reasoning model from OpenAI:
+
+* **Open license (Apache 2.0)** → free to use and fine-tune.
+* **Reasoning focus** → trained with the Harmony format for chain-of-thought.
+* **Biomedical strength** → on *HealthBench*, GPT-OSS-20B at high reasoning outperforms GPT-4o/o1, approaching o3.
+* **Hardware** → runs on a single 16–24 GB GPU with MXFP4 quantization; FP16 requires \~40–50GB VRAM; CPU-only is possible but very slow.
+
+* Step-by-step tutorial for running [OpenAI’s open-weight 20B model](https://huggingface.co/openai/gpt-oss-20b) on CUREBench: [tutorials/tutorial_gptoss20b.md](tutorials/tutorial_gptoss20b.md)
 
 ## 📁 Project Structure
 
@@ -83,17 +94,26 @@ python run.py --config metadata_config_test.json
 ## 🔧 Configuration
 
 ### Metadata Configuration
-Create a `metadata_config_val.json` file:
+Create a `metadata_config_val.json` file. Below is a **single JSON template** with **inline examples** for two common cases:
+
 ```json
 {
   "metadata": {
+    // Example A: ChatGPT (API model)
     "model_name": "gpt-4o-1120",
     "model_type": "ChatGPTModel",
     "track": "internal_reasoning",
     "base_model_type": "API",
     "base_model_name": "gpt-4o-1120",
+
+    // Example B: GPT-OSS-20B (open-weight model)
+    // "model_name": "openai/gpt-oss-20b",
+    // "model_type": "LocalModel",
+    // "base_model_type": "OpenWeighted",
+    // "base_model_name": "openai/gpt-oss-20b",
+
     "dataset": "cure_bench_pharse_1",
-    "additional_info": "",
+    "additional_info": "", // e.g. "Zero-shot GPT-OSS-20B run"
     "average_tokens_per_question": "",
     "average_tools_per_question": "",
     "tool_category_coverage": ""
@@ -106,6 +126,14 @@ Create a `metadata_config_val.json` file:
   "output_dir": "competition_results",
   "output_file": "submission.csv"
 }
+```
+
+**Notes:**
+
+* Other API models and open-weight models (e.g. Qwen) can be used in the same way
+* For fine-tuned model (e.g. GPT-OSS-20B) replace `"model_name"` with your fine-tuned checkpoint, e.g.:
+```json
+"model_name": "myuser/gpt-oss-20b-curebench-ft"
 ```
 
 ### Required Metadata Fields
@@ -135,15 +163,24 @@ The framework generates submission files in CSV format with a zip package contai
 - `reasoning_trace`: Model's reasoning process
 - `choice`: The choice for the multi-choice questions.
 
-The accompanying metadata includes:
+The generated submission also includes metadata. Below is a **combined example** showing ChatGPT vs GPT-OSS-20B variants:
+
 ```json
 {
   "meta_data": {
+    // Example A: ChatGPT
     "model_name": "gpt-4o-1120",
     "track": "internal_reasoning",
     "model_type": "ChatGPTModel",
     "base_model_type": "API", 
     "base_model_name": "gpt-4o-1120",
+
+    // Example B: GPT-OSS-20B
+    // "model_name": "openai/gpt-oss-20b",
+    // "model_type": "LocalModel",
+    // "base_model_type": "OpenWeighted",
+    // "base_model_name": "openai/gpt-oss-20b",
+
     "dataset": "cure_bench_pharse_1",
     "additional_info": "",
     "average_tokens_per_question": "",

--- a/tutorials/tutorial_gptoss20b.md
+++ b/tutorials/tutorial_gptoss20b.md
@@ -1,0 +1,97 @@
+# Tutorial: Running GPT-OSS-20B on CUREBench
+
+This tutorial explains how to use [OpenAI’s open-weight `gpt-oss-20b`](https://huggingface.co/openai/gpt-oss-20b) with the CUREBench starter kit.
+
+---
+
+## Why GPT-OSS-20B?
+
+
+- Optimized for **reasoning** (trained with Harmony format). Access to model's reasoning process, facilitating simpler debugging and output trust.
+- 📖 **Open-weight + Apache 2.0 license** (able to fine-tune and build freely).
+- Strong performance on **health-related benchmarks** strong results on *HealthBench*, surpassing GPT-4o/o1 and approaching o3 on real doctor–patient tasks.
+- Runs on 16-24 GB GPUs with MXFP4 quantization. 
+
+---
+
+## 1. Install Dependencies
+
+Make sure you have the starter kit installed:
+
+```bash
+pip install -r requirements.txt
+pip install transformers bitsandbytes accelerate
+
+> **Notes:**
+>
+> * `bitsandbytes` → enables 8-bit quantization so GPT-OSS-20B can run on a single 16GB GPU.
+> * `accelerate` → helps with device placement and multi-GPU inference.
+
+````
+```
+---
+
+## 2. Configure Dataset
+
+Here’s an example `metadata_config_val.json` for running GPT-OSS-20B zero-shot:
+
+```json
+{
+  "metadata": {
+    "model_name": "openai/gpt-oss-20b",
+    "model_type": "LocalModel",
+    "track": "internal_reasoning",
+    "base_model_type": "OpenWeighted",
+    "base_model_name": "openai/gpt-oss-20b",
+    "dataset": "cure_bench_phase_1",
+    "additional_info": "Zero-shot GPT-OSS-20B run",
+    "average_tokens_per_question": "",
+    "average_tools_per_question": "",
+    "tool_category_coverage": ""
+  },
+  "dataset": {
+    "dataset_name": "cure_bench_phase_1",
+    "dataset_path": "data/curebench_valset_phase1.jsonl",
+    "description": "CureBench 2025 validation questions"
+  },
+  "output_dir": "competition_results",
+  "output_file": "submission_val.csv"
+}
+```
+
+---
+
+## 3. Run Zero-Shot Evaluation
+
+Run the evaluation with:
+
+```bash
+python run.py --config metadata_config_val.json
+```
+
+This will:
+
+* Load GPT-OSS-20B via Hugging Face.
+* Evaluate it on the CUREBench validation set.
+* Save predictions and reasoning traces to `competition_results/submission_val.csv`.
+
+---
+
+## 4. Hardware Requirements
+
+* MXFP4 quantization: 16–24 GB GPU.
+* FP16: \~40–50 GB VRAM (e.g., A100, H100, MI300).
+* 8-bit quantization: runs on 16–24 GB GPUs (`bitsandbytes`).
+* CPU: possible, but very slow.
+
+---
+
+## 5. Fine-Tuned Usage (Optional)
+
+If you fine-tune GPT-OSS-20B, simply change the model name:
+
+```json
+"model_name": "myuser/gpt-oss-20b-curebench-ft"
+```
+
+No wrapper changes or code modifications are required: the framework will load your checkpoint automatically.


### PR DESCRIPTION
## Overview

This PR introduces a simple, participant-facing guide for using **[[OpenAI’s GPT-OSS-20B](https://huggingface.co/openai/gpt-oss-20b)](https://huggingface.co/openai/gpt-oss-20b)** in the CUREBench competition. GPT-OSS-20B is an **open-weight reasoning model** (Apache 2.0 license) that participants can run locally or fine-tune for improved performance.

The changes provide clear, step-by-step instructions for both **zero-shot usage** and **fine-tuned checkpoints**, lowering the barrier for participants who want to experiment with open-weight models.

---

## Key Changes

### 1. Updated `README.md`

* Added instructions for running GPT-OSS-20B alongside existing API and open-weight models.
* Expanded metadata configuration examples to include **GPT-OSS-20B** for both zero-shot and fine-tuned cases.
* Clarified hardware requirements and quantization options (FP16 vs MXFP4 vs 8-bit).

### 2. New Tutorial

* Added **`tutorials/tutorial_gptoss20b.md`**:

  * Installation instructions (`transformers`, `bitsandbytes`, `accelerate`).
  * Example JSON config for zero-shot evaluation.
  * Step-by-step run command:

    ```bash
    python run.py --config metadata_config_val.json
    ```
  * Guidance on fine-tuned usage (replace `model_name` with custom checkpoint).
  * Hardware requirements across quantization levels.

---

## Impact

This PR directly supports CUREBench participants by:

* Demonstrating **how to run GPT-OSS-20B zero-shot** with the starter kit.
* Showing how to easily plug in **fine-tuned GPT-OSS-20B models**.
* Broadening competition accessibility to open-weight reasoning models.

---